### PR TITLE
(#4) ThemeProvider로 전역으로 디자인 시스템 설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
 import './App.css'
 
-import styled from 'styled-components'
+import styled, { ThemeProvider } from 'styled-components'
 import GlobalStyle from './styles/GlobalStyle'
+import { theme } from './styles/theme'
 
 const Container = styled.div`
   display: flex;
@@ -15,8 +16,10 @@ const Container = styled.div`
 export default function App() {
   return (
     <>
-      <GlobalStyle />
-      <Container>화면 적용</Container>
+      <ThemeProvider theme={theme}>
+        <GlobalStyle />
+        <Container>화면 적용</Container>
+      </ThemeProvider>
     </>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,16 @@
   height: 100vh;
 }
 
+@font-face {
+  font-family: 'SUITE-Regular';
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2304-2@1.0/SUITE-Regular.woff2')
+    format('woff2');
+  font-weight: 400;
+  font-style: normal;
+}
+body {
+  font-family: 'SUITE-Regular', sans-serif;
+}
 a {
   font-weight: 500;
   color: #646cff;

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -9,7 +9,7 @@ const GlobalStyle = createGlobalStyle`
     display: flex;
     flex-direction: column;
     max-width: 400px;
-    background-color: #f9faff;
+    background-color: #F8F8F8;
     border-color: black;
     align-items: center;
   }

--- a/src/styles/styled.d.ts
+++ b/src/styles/styled.d.ts
@@ -1,0 +1,9 @@
+import 'styled-components'
+import { ColorsTypes, FontsTypes } from './theme'
+
+declare module 'styled-components' {
+  export interface DefaultTheme {
+    colors: ColorsTypes
+    fonts: FontsTypes
+  }
+}

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,86 @@
+import { DefaultTheme } from 'styled-components'
+
+export const colors = {
+  orange: '#f87f01',
+  yellow: '#fdd100',
+  mintGreen: '#e7f0ed',
+  navy: '#435969',
+}
+
+interface Font {
+  font: string
+  weight: number
+  size: number
+  lineHeight: number
+}
+
+const FONT = ({ font, weight, size, lineHeight }: Font): string => {
+  return `
+        font-family : "${font}";
+        font-weight : ${weight};
+        font-size : ${size}rem;
+        line-height : ${lineHeight}%;
+        `
+}
+
+export const fonts = {
+  // 제목
+  title1: FONT({
+    font: 'SUITE-Regular',
+    weight: 700,
+    size: 2.4,
+    lineHeight: 32,
+  }),
+  title2: FONT({
+    font: 'SUITE-Regular',
+    weight: 700,
+    size: 2.0,
+    lineHeight: 28,
+  }),
+
+  // 본문
+  body1: FONT({
+    font: 'SUITE-Regular',
+    weight: 700,
+    size: 2.0,
+    lineHeight: 25,
+  }),
+  body2: FONT({
+    font: 'SUITE-Regular',
+    weight: 500,
+    size: 1.5,
+    lineHeight: 26,
+  }),
+  body3: FONT({
+    font: 'SUITE-Regular',
+    weight: 500,
+    size: 1.4,
+    lineHeight: 24,
+  }),
+  body4: FONT({
+    font: 'SUITE-Regular',
+    weight: 700,
+    size: 1.3,
+    lineHeight: 22,
+  }),
+  body5: FONT({
+    font: 'SUITE-Regular',
+    weight: 700,
+    size: 1.2,
+    lineHeight: 20,
+  }),
+  body6: FONT({
+    font: 'SUITE-Regular',
+    weight: 500,
+    size: 1.1,
+    lineHeight: 18,
+  }),
+}
+
+export type ColorsTypes = typeof colors
+export type FontsTypes = typeof fonts
+
+export const theme: DefaultTheme = {
+  colors,
+  fonts,
+}

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -25,7 +25,7 @@ const FONT = ({ font, weight, size, lineHeight }: Font): string => {
   return `
         font-family : "${font}";
         font-weight : ${weight};
-        font-size : ${size}rem;
+        font-size : ${size}px;
         line-height : ${lineHeight}%;
         `
 }
@@ -34,14 +34,14 @@ export const fonts = {
   // 제목
   title1: FONT({
     font: 'SUITE-Regular',
-    weight: 700,
-    size: 2.4,
+    weight: 900,
+    size: 24,
     lineHeight: 32,
   }),
   title2: FONT({
     font: 'SUITE-Regular',
     weight: 700,
-    size: 2.0,
+    size: 20,
     lineHeight: 28,
   }),
 
@@ -49,37 +49,37 @@ export const fonts = {
   body1: FONT({
     font: 'SUITE-Regular',
     weight: 700,
-    size: 2.0,
+    size: 20,
     lineHeight: 25,
   }),
   body2: FONT({
     font: 'SUITE-Regular',
     weight: 500,
-    size: 1.5,
+    size: 15,
     lineHeight: 26,
   }),
   body3: FONT({
     font: 'SUITE-Regular',
     weight: 500,
-    size: 1.4,
+    size: 14,
     lineHeight: 24,
   }),
   body4: FONT({
     font: 'SUITE-Regular',
     weight: 700,
-    size: 1.3,
+    size: 13,
     lineHeight: 22,
   }),
   body5: FONT({
     font: 'SUITE-Regular',
     weight: 700,
-    size: 1.2,
+    size: 12,
     lineHeight: 20,
   }),
   body6: FONT({
     font: 'SUITE-Regular',
     weight: 500,
-    size: 1.1,
+    size: 11,
     lineHeight: 18,
   }),
 }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -3,8 +3,15 @@ import { DefaultTheme } from 'styled-components'
 export const colors = {
   orange: '#f87f01',
   yellow: '#fdd100',
+  lightYellow: '#FFEE9C',
   mintGreen: '#e7f0ed',
   navy: '#435969',
+  gray1: '#767676',
+  gray2: '#FFEE9C',
+  idGray: '#9A9A9A',
+  lightGray: '#E7E7E7',
+  black: '#000000',
+  white: '#FFFFFF',
 }
 
 interface Font {


### PR DESCRIPTION
## 📢 기능 설명

- index.css에 전체 폰트 설정을 했습니다.
- 피그마에 있는 색상과 폰트 크기를 전역으로 뽑아서 쓸 수 있도록 했습니다.

<img width="227" alt="스크린샷 2024-07-16 오후 3 26 27" src="https://github.com/user-attachments/assets/0c19b736-7c23-4f90-921d-5bde6ad5c9f2">
<img width="699" alt="스크린샷 2024-07-16 오후 3 26 18" src="https://github.com/user-attachments/assets/b96ae866-ebf6-450e-999e-53c50148d158">

이런 식으로 ` ${theme.~~}` 쓰면 됩니다!

<img width="407" alt="스크린샷 2024-07-16 오후 3 31 28" src="https://github.com/user-attachments/assets/d57af3f9-8f07-43d4-b27f-34c11adf4c5f">

위에부터 title1,2 / body 1,2,3,4,5,6입니다!

<br>

## 연결된 issue
close #4
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
<br>

## ✅ 체크리스트

- [X] PR 제목 규칙 잘 지켰는가?
- [X] 추가/수정사항을 설명하였는가?
- [X] 이슈넘버를 적었는가?
- [X] Approve 하기 전 확인 사항 체크했는가?
