### PR TITLE
(#23)feat/deleteStore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react-icons": "^5.2.1",
         "react-router-dom": "^6.24.1",
         "styled-components": "^6.1.11",
+        "uuid": "^10.0.0",
         "zustand": "^4.5.4"
       },
       "devDependencies": {
@@ -23,6 +24,7 @@
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@types/styled-components": "^5.1.34",
+        "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^7.16.1",
         "@typescript-eslint/parser": "^7.16.1",
         "@vitejs/plugin-react": "^4.3.1",
@@ -1404,6 +1406,12 @@
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
       "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.16.1",
@@ -5936,6 +5944,18 @@
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-icons": "^5.2.1",
     "react-router-dom": "^6.24.1",
     "styled-components": "^6.1.11",
+    "uuid": "^10.0.0",
     "zustand": "^4.5.4"
   },
   "devDependencies": {
@@ -31,6 +32,7 @@
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@types/styled-components": "^5.1.34",
+    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^7.16.1",
     "@typescript-eslint/parser": "^7.16.1",
     "@vitejs/plugin-react": "^4.3.1",

--- a/src/apis/Store/deleteStore.ts
+++ b/src/apis/Store/deleteStore.ts
@@ -1,0 +1,13 @@
+import axios from 'axios'
+
+const API_BASE_URL = 'https://api.example.com' // 실제 API 기본 URL로 대체하기
+
+export const deleteStore = async (storeId: number) => {
+  try {
+    const response = await axios.delete(`${API_BASE_URL}/v1/stores/${storeId}`)
+    return response.data.result.id
+  } catch (error) {
+    console.error('Error deleting store:', error)
+    throw error
+  }
+}

--- a/src/apis/Store/deleteStore.ts
+++ b/src/apis/Store/deleteStore.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
-const API_BASE_URL = 'http://43.201.218.182:8080' // 실제 API 기본 URL로 대체하기
-
+const API_BASE_URL = 'http://43.201.218.182:8080'
+//기본 엔드포인트는 추후 env에다가 설정해두는게 좋을 거 같네요
 export const deleteStore = async (storeId: number) => {
   try {
     const response = await axios.delete(`/v1/stores/${storeId}`)

--- a/src/apis/Store/deleteStore.ts
+++ b/src/apis/Store/deleteStore.ts
@@ -1,10 +1,11 @@
 import axios from 'axios'
 
-const API_BASE_URL = 'https://api.example.com' // 실제 API 기본 URL로 대체하기
+const API_BASE_URL = 'http://43.201.218.182:8080' // 실제 API 기본 URL로 대체하기
 
 export const deleteStore = async (storeId: number) => {
   try {
-    const response = await axios.delete(`${API_BASE_URL}/v1/stores/${storeId}`)
+    const response = await axios.delete(`/v1/stores/${storeId}`)
+    console.log(response.data)
     return response.data.result.id
   } catch (error) {
     console.error('Error deleting store:', error)

--- a/src/components/ManagerCompletedCard/ManagerCompletedCard.tsx
+++ b/src/components/ManagerCompletedCard/ManagerCompletedCard.tsx
@@ -20,22 +20,31 @@ export default function ManagerCompletedCard() {
 
   return (
     <CardContainer>
-      <CardTitle>{managerName} 사장님의</CardTitle>
-      <CardSubtitle>{storeInfos[0].name}</CardSubtitle>
-      <CardContent>
-        <CardButton onClick={() => navigate('/discount-event')}>
-          <span>할인행사</span>
-          <span>진행하기</span>
-        </CardButton>
-        <CardButton onClick={() => navigate('/discount-record')}>
-          <span>진행했던</span>
-          <span>할인행사 보기</span>
-        </CardButton>
-      </CardContent>
-      <EditButton onClick={() => navigate('/storeInfo-edit')}>
-        가게 정보 수정하기
-        <ArrowIcon>&gt;</ArrowIcon>
-      </EditButton>
+      {storeInfos && storeInfos.length > 0 ? (
+        <>
+          <CardTitle>{managerName} 사장님의</CardTitle>
+          <CardSubtitle>{storeInfos[0].name}</CardSubtitle>
+          <CardContent>
+            <CardButton onClick={() => navigate('/discount-event')}>
+              <span>할인행사</span>
+              <span>진행하기</span>
+            </CardButton>
+            <CardButton onClick={() => navigate('/discount-record')}>
+              <span>진행했던</span>
+              <span>할인행사 보기</span>
+            </CardButton>
+          </CardContent>
+          <EditButton onClick={() => navigate('/storeInfo-edit')}>
+            가게 정보 수정하기
+            <ArrowIcon>&gt;</ArrowIcon>
+          </EditButton>
+        </>
+      ) : (
+        <>
+          <CardTitle>{managerName} 사장님의</CardTitle>
+          <CardSubtitle>등록된 가게가 없습니다.</CardSubtitle>
+        </>
+      )}
     </CardContainer>
   )
 }

--- a/src/pages/DiscountEventPage/DiscountEventPage/DiscountEventPage.style.ts
+++ b/src/pages/DiscountEventPage/DiscountEventPage/DiscountEventPage.style.ts
@@ -162,6 +162,7 @@ export const MenuRow = styled.div`
 export const MenuLabel = styled.span`
   font-size: 1rem;
   font-weight: 400;
+  min-width: 55px;
 `
 
 export const PriceInput = styled.input`

--- a/src/pages/DiscountEventPage/DiscountEventPage/DiscountEventPage.tsx
+++ b/src/pages/DiscountEventPage/DiscountEventPage/DiscountEventPage.tsx
@@ -70,7 +70,7 @@ export default function DiscountEventPage() {
       hasError = true
     }
 
-    let hasValidDiscount = currentEvent.discounts.every(
+    let hasValidDiscount = currentEvent.discounts.some(
       (discount) => discount.isChecked && discount.discountPrice,
     )
 

--- a/src/pages/DiscountEventPage/DiscountEventPage/DiscountEventPage.tsx
+++ b/src/pages/DiscountEventPage/DiscountEventPage/DiscountEventPage.tsx
@@ -51,6 +51,7 @@ export default function DiscountEventPage() {
   }, [storeInfos[0].menu, initializeDiscounts])
 
   const handleNextClick = () => {
+    //유효성 검사 로직 커스텀훅으로 분리 예정
     let periodError = ''
     let discountError = ''
     let hasError = false
@@ -69,12 +70,9 @@ export default function DiscountEventPage() {
       hasError = true
     }
 
-    let hasValidDiscount = false
-    for (const discount of currentEvent.discounts) {
-      if (discount.isChecked && discount.discountPrice) {
-        hasValidDiscount = true
-      }
-    }
+    let hasValidDiscount = currentEvent.discounts.every(
+      (discount) => discount.isChecked && discount.discountPrice,
+    )
 
     if (!hasValidDiscount) {
       discountError = '적용할 메뉴를 선택하고 가격을 입력해주세요.'
@@ -123,6 +121,33 @@ export default function DiscountEventPage() {
           ? '종료 날짜는 시작 날짜보다 이후이어야 합니다.'
           : '',
     }))
+  }
+
+  const handleCheckboxClick = (id: number, checked: boolean) => {
+    const discount = currentEvent.discounts.find((d) => d.id === id)
+    if (discount && discount.discountPrice > 0) {
+      setDiscountChecked(id, checked)
+      setErrorMessages((prev) => ({
+        ...prev,
+        discountError: '',
+      }))
+    } else {
+      setErrorMessages((prev) => ({
+        ...prev,
+        discountError: '가격을 입력해주세요.',
+      }))
+    }
+  }
+
+  const handlePriceChange = (id: number, price: number) => {
+    setDiscountPrice(id, price)
+    const discount = currentEvent.discounts.find((d) => d.id === id)
+    if (discount && price > 0) {
+      setErrorMessages((prev) => ({
+        ...prev,
+        discountError: '',
+      }))
+    }
   }
 
   return (
@@ -179,11 +204,7 @@ export default function DiscountEventPage() {
                   <PriceInput
                     type="text"
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                      setDiscountPrice(item.id, Number(e.target.value) || 0)
-                      setErrorMessages((prev) => ({
-                        ...prev,
-                        discountError: '',
-                      }))
+                      handlePriceChange(item.id, Number(e.target.value) || 0)
                     }}
                   />
                   <CheckboxWrapper>
@@ -191,11 +212,7 @@ export default function DiscountEventPage() {
                       type="checkbox"
                       id={`menu${item.id}`}
                       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                        setDiscountChecked(item.id, e.target.checked)
-                        setErrorMessages((prev) => ({
-                          ...prev,
-                          discountError: '',
-                        }))
+                        handleCheckboxClick(item.id, e.target.checked)
                       }}
                     />
                     <label htmlFor={`menu${item.id}`}></label>

--- a/src/pages/DiscountEventRecordPage/DiscountEventRecordPage.style.ts
+++ b/src/pages/DiscountEventRecordPage/DiscountEventRecordPage.style.ts
@@ -46,6 +46,7 @@ export const EventItem = styled.div`
   margin-bottom: 10px;
   border-radius: 10px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  position: relative;
 `
 
 export const EventTitle = styled.div`
@@ -63,4 +64,16 @@ export const EventPeriod = styled.div`
   font-size: 0.8rem;
   color: gray;
   margin-top: 5px;
+`
+export const DeleteButton = styled.button`
+  position: absolute;
+  bottom: 15px;
+  right: 15px;
+  background-color: #ff6b6b;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  padding: 5px 10px;
+  cursor: pointer;
+  box-sizing: border-box;
 `

--- a/src/pages/DiscountEventRecordPage/DiscountEventRecordPage.tsx
+++ b/src/pages/DiscountEventRecordPage/DiscountEventRecordPage.tsx
@@ -18,10 +18,10 @@ import discountEventStore from '@stores/discountEventStore'
 export default function DiscountEventRecordPage() {
   const navigate = useNavigate()
   const { storeInfos } = storeInfoStore()
-  const { discountEvents, removeDiscountEventsByStoreId } = discountEventStore()
+  const { discountEvents, removeDiscountEventById } = discountEventStore()
 
-  const handleDeleteClick = (storeId: number) => {
-    removeDiscountEventsByStoreId(storeId)
+  const handleDeleteClick = (eventId: number) => {
+    removeDiscountEventById(eventId)
   } //여기 API 코드는 브렌치 새로 파서 진행하겠습니다(본격적인 할인 로직 다룰때)
   //현재는 클라이언트 단에서(스토어) 삭제되는거까지만 해놨습니다.
   console.log(discountEvents)
@@ -48,7 +48,7 @@ export default function DiscountEventRecordPage() {
             <EventPeriod>
               {event.startDate} ~ {event.endDate}
             </EventPeriod>
-            <DeleteButton onClick={() => handleDeleteClick(event.storeId)}>
+            <DeleteButton onClick={() => handleDeleteClick(event.id)}>
               삭제
             </DeleteButton>
           </EventItem>

--- a/src/pages/DiscountEventRecordPage/DiscountEventRecordPage.tsx
+++ b/src/pages/DiscountEventRecordPage/DiscountEventRecordPage.tsx
@@ -9,6 +9,7 @@ import {
   EventTitle,
   EventDescription,
   EventPeriod,
+  DeleteButton,
 } from '@pages/DiscountEventRecordPage/DiscountEventRecordPage.style'
 import { useNavigate } from 'react-router-dom'
 import storeInfoStore from '@stores/storeInfoStore'
@@ -17,8 +18,13 @@ import discountEventStore from '@stores/discountEventStore'
 export default function DiscountEventRecordPage() {
   const navigate = useNavigate()
   const { storeInfos } = storeInfoStore()
-  const { discountEvents } = discountEventStore()
+  const { discountEvents, removeDiscountEventsByStoreId } = discountEventStore()
 
+  const handleDeleteClick = (storeId: number) => {
+    removeDiscountEventsByStoreId(storeId)
+  } //여기 API 코드는 브렌치 새로 파서 진행하겠습니다(본격적인 할인 로직 다룰때)
+  //현재는 클라이언트 단에서(스토어) 삭제되는거까지만 해놨습니다.
+  console.log(discountEvents)
   return (
     <PageContainer>
       <Header>
@@ -42,6 +48,9 @@ export default function DiscountEventRecordPage() {
             <EventPeriod>
               {event.startDate} ~ {event.endDate}
             </EventPeriod>
+            <DeleteButton onClick={() => handleDeleteClick(event.storeId)}>
+              삭제
+            </DeleteButton>
           </EventItem>
         ))}
       </EventList>

--- a/src/pages/DiscountEventRecordPage/DiscountEventRecordPage.tsx
+++ b/src/pages/DiscountEventRecordPage/DiscountEventRecordPage.tsx
@@ -36,15 +36,6 @@ export default function DiscountEventRecordPage() {
           <EventItem key={event.id}>
             <EventTitle>{storeInfos[0].name}</EventTitle>
             <EventDescription>{event.eventMessage}</EventDescription>
-            {event.discounts
-              .filter(
-                (discount) => discount.isChecked && discount.discountPrice > 0,
-              )
-              .map((discount) => (
-                <EventDescription key={discount.id}>
-                  {discount.name} {discount.discountPrice}원 할인
-                </EventDescription>
-              ))}
             <EventPeriod>
               {event.startDate} ~ {event.endDate}
             </EventPeriod>

--- a/src/pages/ManagerPage/ManagerPage.tsx
+++ b/src/pages/ManagerPage/ManagerPage.tsx
@@ -63,7 +63,7 @@ export default function ManagerPage() {
 
   const handleStoreRegisterClick = (): void => {
     const newStore: StoreInfo = {
-      id: storeInfos.length,
+      id: storeInfos.length + 1,
       name: '새로운 가게',
       storeLink: '',
       image: '',

--- a/src/pages/ManagerPage/ManagerPage.tsx
+++ b/src/pages/ManagerPage/ManagerPage.tsx
@@ -22,6 +22,7 @@ import ManagerCompletedCard from '@components/ManagerCompletedCard/ManagerComple
 import storeInfoStore, { StoreInfo } from '@stores/storeInfoStore'
 import NotifyIcon from '@components/NotifyIcon'
 import discountEventStore from '@stores/discountEventStore'
+import { generateUniqueId } from '@utils/generateUniqueId'
 
 export default function ManagerPage() {
   const { isRegistered, setIsRegistered, setManagerRegistrationInfo } =
@@ -63,7 +64,7 @@ export default function ManagerPage() {
 
   const handleStoreRegisterClick = (): void => {
     const newStore: StoreInfo = {
-      id: storeInfos.length + 1,
+      id: generateUniqueId(),
       name: '새로운 가게',
       storeLink: '',
       image: '',

--- a/src/pages/ManagerPage/ManagerPage.tsx
+++ b/src/pages/ManagerPage/ManagerPage.tsx
@@ -15,18 +15,21 @@ import {
 } from './ManagerPage.style'
 import icon from '@assets/managerMypage/등록증 아이콘.svg'
 import menuIcon from '@assets/managerMypage/메뉴아이콘.svg'
-import bellIcon from '@assets/icons/bell.svg'
 import useModalStore from '@stores/modalStore'
 import { useEffect, useState } from 'react'
 import DiscountModal from '@components/Modal/DiscountModal'
 import ManagerCompletedCard from '@components/ManagerCompletedCard/ManagerCompletedCard'
-import storeInfoStore from '@stores/storeInfoStore'
+import storeInfoStore, { StoreInfo } from '@stores/storeInfoStore'
 import NotifyIcon from '@components/NotifyIcon'
+import discountEventStore from '@stores/discountEventStore'
 
 export default function ManagerPage() {
   const { isRegistered, setIsRegistered, setManagerRegistrationInfo } =
     managerRegisterInfoStore()
   const { isStoreRegistered, setStoreRegistered } = storeInfoStore()
+  const addStoreInfo = storeInfoStore((state) => state.addStoreInfo)
+  const storeInfos = storeInfoStore((state) => state.storeInfos)
+  const { discountEvents } = discountEventStore()
   const { openModal } = useModalStore()
   const [businessData, setBusinessData] = useState<ManagerRegisterState | null>(
     null,
@@ -39,6 +42,11 @@ export default function ManagerPage() {
       setBusinessData(null)
     }
   }, [isRegistered])
+
+  useEffect(() => {
+    console.log('Updated Store Infos:', storeInfos) // storeInfos 변경 시 로그 찍기
+  }, [storeInfos])
+  console.log(discountEvents)
 
   const handleManagerRegisterClick = (): void => {
     setIsRegistered(true)
@@ -54,10 +62,43 @@ export default function ManagerPage() {
   }
 
   const handleStoreRegisterClick = (): void => {
+    const newStore: StoreInfo = {
+      id: storeInfos.length,
+      name: '새로운 가게',
+      storeLink: '',
+      image: '',
+      university: '',
+      businessHours: [],
+      breakTime: [],
+      menu: [
+        //임의로 메뉴 데이터가 입력된다고 가정
+        {
+          id: 0,
+          image: '/assets/icons/bell.svg',
+          name: '김치찌개',
+          price: 8000,
+          isDiscounted: false,
+        },
+        {
+          id: 1,
+          image: '/assets/icons/bell.svg',
+          name: '된장찌개',
+          price: 7500,
+          isDiscounted: false,
+        },
+        {
+          id: 2,
+          image: '/assets/icons/bell.svg',
+          name: '미역국',
+          price: 5000,
+          isDiscounted: false,
+        },
+      ],
+    }
+    addStoreInfo(newStore)
     setStoreRegistered(true)
     openModal()
   }
-
   return (
     <ManagerPageContainer>
       <Title>

--- a/src/pages/StoreInfoDeletePage/StoreInfoDeletePage.tsx
+++ b/src/pages/StoreInfoDeletePage/StoreInfoDeletePage.tsx
@@ -1,3 +1,4 @@
+import { deleteStore } from '@apis/Store/deleteStore'
 import {
   BackButton,
   Checkbox,
@@ -11,23 +12,45 @@ import {
   SubTitle,
   Title,
 } from '@pages/StoreInfoDeletePage/StoreInfoDeletePage.style'
-import { useState } from 'react'
+import storeInfoStore from '@stores/storeInfoStore'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 export default function StoreInfoDeletePage() {
   const navigate = useNavigate()
-  const [isChecked, setIsChecked] = useState(false)
+  const [isChecked, setIsChecked] = useState<boolean>(false)
+  const storeInfos = storeInfoStore((state) => state.storeInfos)
+  const removeStoreInfo = storeInfoStore((state) => state.removeStoreInfo)
+
+  // 현재 등록된 가게 정보가 없을 경우에 대한 처리
+  const storeId = storeInfos.length > 0 ? storeInfos[0].id : null
+
+  useEffect(() => {
+    console.log('Store Infos before deletion:', storeInfos)
+  }, [])
+
+  useEffect(() => {
+    console.log('Updated Store Infos after deletion:', storeInfos)
+  }, [storeInfos])
 
   const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setIsChecked(e.target.checked)
   }
-
-  const handleDeleteClick = () => {
-    if (isChecked) {
-      // 가게 삭제 로직 나중에 추가
-      navigate('/manager')
-    } else {
-      return
+  //실제 api 다룰때는 api함수 호출 -> 리턴받은 id 받고 removeStore에 인자로 보내주기 -> 가게 정보 업뎃
+  //현재는 일단 removeStore를 통해 스토어에서 없어지는거 확인
+  const handleDeleteClick = async () => {
+    if (isChecked && storeId !== null) {
+      try {
+        //const deletedStoreId = await deleteStore(storeId) - api 다루는 부분
+        //removeStoreInfo(deletedStoreId) - 반환받은 부분
+        removeStoreInfo(storeId)
+        const updatedStoreInfos = storeInfoStore.getState().storeInfos
+        console.log(`Store with ID ${storeId} deleted successfully`)
+        console.log('Updated Store Infos:', updatedStoreInfos)
+        navigate('/manager')
+      } catch (error) {
+        console.error('Error deleting store:', error)
+      }
     }
   }
   return (

--- a/src/stores/discountEventStore.ts
+++ b/src/stores/discountEventStore.ts
@@ -1,8 +1,5 @@
 import { create } from 'zustand'
-
-const generateUniqueId = () => {
-  return Math.floor(Math.random() * 1000000) // 0에서 999,999 사이의 랜덤 숫자 생성
-}
+import { generateUniqueId } from '@utils/generateUniqueId'
 
 interface Discount {
   id: number

--- a/src/stores/discountEventStore.ts
+++ b/src/stores/discountEventStore.ts
@@ -1,5 +1,9 @@
 import { create } from 'zustand'
 
+const generateUniqueId = () => {
+  return Math.floor(Math.random() * 1000000) // 0에서 999,999 사이의 랜덤 숫자 생성
+}
+
 interface Discount {
   id: number
   name: string
@@ -9,7 +13,6 @@ interface Discount {
 
 interface DiscountEvent {
   id: number
-  storeId: number // 가게 ID와 연결되는 필드 추가
   startDate: string
   endDate: string
   eventMessage: string
@@ -33,13 +36,12 @@ interface DiscountEventState {
     }[],
   ) => void
   addDiscountEvent: () => DiscountEvent
-  removeDiscountEventsByStoreId: (storeId: number) => void
+  removeDiscountEventById: (eventId: number) => void
 }
 
 const discountEventStore = create<DiscountEventState>((set, get) => ({
   currentEvent: {
     id: 0,
-    storeId: 0,
     startDate: '',
     endDate: '',
     eventMessage: '',
@@ -95,14 +97,12 @@ const discountEventStore = create<DiscountEventState>((set, get) => ({
     const state = get()
     const newEvent: DiscountEvent = {
       ...state.currentEvent,
-      id: state.discountEvents.length,
-      storeId: state.currentEvent.storeId, // 현재 이벤트의 storeId 사용
+      id: generateUniqueId(), // 고유한 ID 생성 함수 사용
     }
     set({
       discountEvents: [...state.discountEvents, newEvent],
       currentEvent: {
         id: 0,
-        storeId: 0,
         startDate: '',
         endDate: '',
         eventMessage: '',
@@ -111,10 +111,10 @@ const discountEventStore = create<DiscountEventState>((set, get) => ({
     })
     return newEvent
   },
-  removeDiscountEventsByStoreId: (storeId) => {
+  removeDiscountEventById: (eventId) => {
     set((state) => ({
       discountEvents: state.discountEvents.filter(
-        (event) => event.storeId !== storeId,
+        (event) => event.id !== eventId,
       ),
     }))
   },

--- a/src/stores/discountEventStore.ts
+++ b/src/stores/discountEventStore.ts
@@ -32,6 +32,7 @@ interface DiscountEventState {
     }[],
   ) => void
   addDiscountEvent: () => DiscountEvent
+  removeDiscountEventsByStoreId: (storeId: number) => void
 }
 
 const discountEventStore = create<DiscountEventState>((set, get) => ({
@@ -105,6 +106,13 @@ const discountEventStore = create<DiscountEventState>((set, get) => ({
       },
     })
     return newEvent
+  },
+  removeDiscountEventsByStoreId: (storeId) => {
+    set((state) => ({
+      discountEvents: state.discountEvents.filter(
+        (event) => event.id !== storeId,
+      ),
+    }))
   },
 }))
 

--- a/src/stores/discountEventStore.ts
+++ b/src/stores/discountEventStore.ts
@@ -9,6 +9,7 @@ interface Discount {
 
 interface DiscountEvent {
   id: number
+  storeId: number // 가게 ID와 연결되는 필드 추가
   startDate: string
   endDate: string
   eventMessage: string
@@ -38,6 +39,7 @@ interface DiscountEventState {
 const discountEventStore = create<DiscountEventState>((set, get) => ({
   currentEvent: {
     id: 0,
+    storeId: 0,
     startDate: '',
     endDate: '',
     eventMessage: '',
@@ -93,12 +95,14 @@ const discountEventStore = create<DiscountEventState>((set, get) => ({
     const state = get()
     const newEvent: DiscountEvent = {
       ...state.currentEvent,
-      id: state.discountEvents.length + 1,
+      id: state.discountEvents.length,
+      storeId: state.currentEvent.storeId, // 현재 이벤트의 storeId 사용
     }
     set({
       discountEvents: [...state.discountEvents, newEvent],
       currentEvent: {
         id: 0,
+        storeId: 0,
         startDate: '',
         endDate: '',
         eventMessage: '',
@@ -110,7 +114,7 @@ const discountEventStore = create<DiscountEventState>((set, get) => ({
   removeDiscountEventsByStoreId: (storeId) => {
     set((state) => ({
       discountEvents: state.discountEvents.filter(
-        (event) => event.id !== storeId,
+        (event) => event.storeId !== storeId,
       ),
     }))
   },

--- a/src/stores/storeInfoStore.ts
+++ b/src/stores/storeInfoStore.ts
@@ -87,7 +87,7 @@ const storeInfoStore = create<StoreInfoState>((set) => ({
     set((state) => {
       const updatedStores = state.storeInfos.filter(
         (store) => store.id !== storeId,
-      ) //가게 정보 삭제 시에 할인정보 스토어에 있는 할인 정보 삭제
+      ) //가게 정보 삭제 시에 가게 id에 해당하는 할인 정보 동시에 삭제
       discountEventStore.getState().removeDiscountEventsByStoreId(storeId)
       console.log('Updated Stores:', updatedStores)
       return {

--- a/src/stores/storeInfoStore.ts
+++ b/src/stores/storeInfoStore.ts
@@ -87,8 +87,7 @@ const storeInfoStore = create<StoreInfoState>((set) => ({
     set((state) => {
       const updatedStores = state.storeInfos.filter(
         (store) => store.id !== storeId,
-      ) //가게 정보 삭제 시에 가게 id에 해당하는 할인 정보 동시에 삭제
-      discountEventStore.getState().removeDiscountEventsByStoreId(storeId)
+      )
       console.log('Updated Stores:', updatedStores)
       return {
         storeInfos: updatedStores,

--- a/src/stores/storeInfoStore.ts
+++ b/src/stores/storeInfoStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import discountEventStore from './discountEventStore'
 
 interface BusinessHours {
   day: string
@@ -16,7 +17,7 @@ export interface MenuItem {
   isDiscounted?: boolean // 추가된 필드
 }
 
-interface StoreInfo {
+export interface StoreInfo {
   id: number // 가게 ID 추가
   name: string
   storeLink: string
@@ -30,6 +31,7 @@ interface StoreInfo {
 interface StoreInfoState {
   storeInfos: StoreInfo[]
   setStoreInfo: (info: StoreInfo) => void
+  addStoreInfo: (info: StoreInfo) => void // 새로운 가게를 추가하는 액션 추가
   isStoreRegistered: boolean
   setStoreRegistered: (registered: boolean) => void
   updateMenuDiscount: (
@@ -38,50 +40,26 @@ interface StoreInfoState {
     discountPrice?: number,
     isDiscounted?: boolean,
   ) => void
+  removeStoreInfo: (storeId: number) => void // 추가
 }
 
 const storeInfoStore = create<StoreInfoState>((set) => ({
-  storeInfos: [
-    {
-      id: 1, // 가게 ID 추가
-      name: '밥이득 김치찌개',
-      storeLink: '',
-      image: '',
-      university: '',
-      businessHours: [],
-      breakTime: [],
-      menu: [
-        {
-          id: 0,
-          image: '',
-          name: '김치찌개',
-          price: 8000,
-          isDiscounted: false,
-        },
-        {
-          id: 1,
-          image: '',
-          name: '된장찌개',
-          price: 7500,
-          isDiscounted: false,
-        },
-        {
-          id: 2,
-          image: '',
-          name: '계란말이',
-          price: 5000,
-          isDiscounted: false,
-        },
-      ],
-    },
-    // 다른 가게도 추가 가능
-  ],
+  storeInfos: [], // 초기값을 빈 배열로 설정
   setStoreInfo: (info) =>
     set((state) => ({
       storeInfos: state.storeInfos.map((store) =>
         store.id === info.id ? info : store,
       ),
     })),
+  addStoreInfo: (info) =>
+    set((state) => {
+      const updatedStoreInfos = [...state.storeInfos, info]
+      console.log('Updated Store Infos:', updatedStoreInfos) // 추가된 가게 정보 확인용 콘솔 로그
+      return {
+        storeInfos: updatedStoreInfos,
+        isStoreRegistered: true,
+      }
+    }),
   isStoreRegistered: false,
   setStoreRegistered: (registered) => set({ isStoreRegistered: registered }),
   updateMenuDiscount: (storeId, menuId, discountPrice, isDiscounted) =>
@@ -105,6 +83,19 @@ const storeInfoStore = create<StoreInfoState>((set) => ({
           : store,
       ),
     })),
+  removeStoreInfo: (storeId) => {
+    set((state) => {
+      const updatedStores = state.storeInfos.filter(
+        (store) => store.id !== storeId,
+      ) //가게 정보 삭제 시에 할인정보 스토어에 있는 할인 정보 삭제
+      discountEventStore.getState().removeDiscountEventsByStoreId(storeId)
+      console.log('Updated Stores:', updatedStores)
+      return {
+        storeInfos: updatedStores,
+        isStoreRegistered: updatedStores.length > 0,
+      }
+    })
+  },
 }))
 
 export default storeInfoStore

--- a/src/utils/generateUniqueId.ts
+++ b/src/utils/generateUniqueId.ts
@@ -1,0 +1,3 @@
+export const generateUniqueId = () => {
+  return Math.floor(Math.random() * 1000000) // 0에서 999,999 사이의 랜덤 숫자 생성
+}

--- a/src/utils/generateUniqueId.ts
+++ b/src/utils/generateUniqueId.ts
@@ -1,3 +1,3 @@
 export const generateUniqueId = () => {
-  return Math.floor(Math.random() * 1000000) // 0에서 999,999 사이의 랜덤 숫자 생성
+  return Math.floor(Math.random() * 10000) // 0에서 999,999 사이의 랜덤 숫자 생성
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
       "@pages/*": ["src/pages/*"],
       "@stores/*": ["src/stores/*"],
       "@styles/*": ["src/styles/*"],
+      "@utils/*": ["src/utils/*"],
       "@icons/*": ["src/assets/icons/*"]
     }
   },

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -10,6 +10,7 @@
       "@pages/*": ["pages/*"],
       "@stores/*": ["src/stores/*"],
       "@styles/*": ["styles/*"],
+      "@utils/*": ["src/utils/*"],
       "@icons/*": ["assets/icons/*"]
     }
   }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,4 +17,13 @@ export default defineConfig({
       '@icons': path.resolve(__dirname, 'src/assets/icons'),
     },
   },
+  server: {
+    proxy: {
+      '/v1': {
+        target: 'http://43.201.218.182:8080',
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       '@pages': path.resolve(__dirname, 'src/pages'),
       '@stores': path.resolve(__dirname, 'src/stores'),
       '@styles': path.resolve(__dirname, 'src/styles'),
+      '@utils': path.resolve(__dirname, 'src/utils'),
       '@icons': path.resolve(__dirname, 'src/assets/icons'),
     },
   },


### PR DESCRIPTION
## 📢 기능 설명

### **수행한 태스크는 다음과 같습니다.**

**코드 리뷰 환영합니다 ㅎㅎ ✨**
<br>
**1. <존재하지 않는 가게 id 인자로 보내는 경우>**
→ db에 삭제되어 있는 상태라 다시 호출 시 404에러 발생(의미: 가게정보 존재  ❌)
→ API 통신 할 때 첨부된 이미지와 같이 해당 코드로 진행 예정입니다
→ deleteStore에 가게 삭제 API 호출하는 axios 로직 있습니다
→ 현재는 api 호출 로직은 주석 처리했고 클라이언트 단에만 반영되도록 했습니다
<div style="display: flex; justify-content: space-between; align-items: center;">
  <img src="https://github.com/user-attachments/assets/5dd37fd7-f396-4705-8337-49ef59af96e1" width="30%" height="200px" alt="Image 1">
  <img src="https://github.com/user-attachments/assets/2a92dc89-8d76-41b1-bb1c-01796e0ff331" width="30%" height="200px" alt="Image 2">
<img src="https://github.com/user-attachments/assets/da0692db-5df5-4076-99ef-0abb5bb9458b" width="30%" height="200px" alt="Image 3">
</div>

**2. <proxy 서버를 통해 백엔드 API에 접근>** <br>
![Untitled (5)](https://github.com/user-attachments/assets/077282b0-631d-48e8-a2dd-d254fc6d51df) <br>
→ 이 부분은 추후 수정 될 수 있습니다

**3. <진행했던 할인행사 페이지 삭제버튼 추가 및 스토어에 반영>** <br>
   <img src="https://github.com/user-attachments/assets/8e4b8157-691a-45ac-814a-e47d4fdc62ab" width="70%" alt="Image 1"> <br>
→ 할인했던 정보 1개씩 삭제 가능
→ 이 부분은 브렌치 새로파서 할인 관련 로직 API 다룰 때 연동할 거 같습니다
→ 현재는 클라이언트 단에 삭제된 데이터 반영됩니다

**4. <고유하게 id 만들어주는 generateUniqueId 함수 구현>** <br>
→ id가 넘 크게 만들어지는거 같아서 범위를 줄여야 될거 같기도 하네요
→ utils폴더에다 구현해놨습니다. <br>
![image](https://github.com/user-attachments/assets/80213ba9-2407-40d8-89d4-2aa48c2c0a08)

**5. <시연 영상>** <br>

https://github.com/user-attachments/assets/26419b7f-cc75-489c-8a38-2c77596e1437


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #23
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [V] PR 제목 규칙 잘 지켰는가?
- [V] 추가/수정사항을 설명하였는가?
- [V] 이슈넘버를 적었는가?
- [V] Approve 하기 전 확인 사항 체크했는가?
