### PR TITLE
(#49)feat/manager mypage api

### DIFF
--- a/src/apis/getOwnerMypage.ts
+++ b/src/apis/getOwnerMypage.ts
@@ -1,0 +1,17 @@
+import axios from 'axios'
+const API = import.meta.env.VITE_API_BASE_URL
+const token = import.meta.env.VITE_APP_API_TOKEN
+
+export const getOwnerMypage = async () => {
+  try {
+    const response = await axios.get(`${API}/v1/users/owner/mypage`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+    return response.data
+  } catch (error) {
+    console.error('사장님 마이페이지 오류', error)
+    throw error
+  }
+}

--- a/src/components/ManagerCompletedCard/ManagerCompletedCard.tsx
+++ b/src/components/ManagerCompletedCard/ManagerCompletedCard.tsx
@@ -16,14 +16,14 @@ import {
 
 export default function ManagerCompletedCard() {
   const { storeInfos } = storeInfoStore()
-  const { managerName } = managerRegisterInfoStore()
   const navigate = useNavigate()
+  const { ownerNickname } = managerRegisterInfoStore()
 
   return (
     <StyledCard $paddingtop="24px" $paddingbottom="20px" $paddingright="19px">
       {storeInfos && storeInfos.length > 0 ? (
         <>
-          <CardSubTitle>{managerName} 사장님의</CardSubTitle>
+          <CardSubTitle>{ownerNickname} 사장님의</CardSubTitle>
           <CardTitle $paddingbottom="13px">{storeInfos[0].name}</CardTitle>
           <CardContent>
             <CardButton onClick={() => navigate('/discount-event')}>
@@ -42,7 +42,7 @@ export default function ManagerCompletedCard() {
         </>
       ) : (
         <>
-          <CardSubtitle>{managerName} 사장님의</CardSubtitle>
+          <CardSubtitle>{ownerNickname} 사장님의</CardSubtitle>
           <CardTitle>등록된 가게가 없습니다.</CardTitle>
         </>
       )}

--- a/src/components/RegistrationPrompt.tsx
+++ b/src/components/RegistrationPrompt.tsx
@@ -3,17 +3,17 @@ import { CardTitle } from '@components/MyPageCard/MyPageCard.style'
 interface RegistrationPromptProps {
   isRegistered: boolean
   businessData?: ManagerRegisterState[] | null
+  ownerNickname: string
 }
 
 export default function RegistrationPrompt({
   isRegistered,
   businessData,
+  ownerNickname,
 }: RegistrationPromptProps) {
-  const managerName =
-    businessData && businessData.length > 0 ? businessData[0].managerName : ''
   return (
     <>
-      <CardTitle>{managerName} 사장님!</CardTitle>
+      <CardTitle>{ownerNickname} 사장님!</CardTitle>
       {isRegistered && businessData ? (
         <>
           <CardTitle>심사가 완료되었습니다</CardTitle>

--- a/src/components/UploadSuccess/UploadSuccess.tsx
+++ b/src/components/UploadSuccess/UploadSuccess.tsx
@@ -11,6 +11,7 @@ import {
 } from './UploadSuccess.style'
 import { useEffect, useState } from 'react'
 import { useStoreName } from '@stores/storeInfoStore'
+import managerRegisterInfoStore from '@stores/managerRegisterInfoStore'
 
 interface UploadSuccessProps {
   retry: () => void
@@ -20,6 +21,7 @@ export default function UploadSuccess({ retry }: UploadSuccessProps) {
   const navigate = useNavigate()
   const location = useLocation()
   const saveStoreName = useStoreName((state) => state.saveStoreName)
+  const { setIsRegistered } = managerRegisterInfoStore()
 
   const [registrationData, setRegistrationData] = useState({
     registrationNumber: '',
@@ -38,6 +40,7 @@ export default function UploadSuccess({ retry }: UploadSuccessProps) {
 
   const handleNextClick = () => {
     saveStoreName(registrationData.storeName)
+    setIsRegistered(true)
     navigate('/registerSuccess')
   }
 

--- a/src/pages/ManagerPage/ManagerPage.tsx
+++ b/src/pages/ManagerPage/ManagerPage.tsx
@@ -1,106 +1,122 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 import RegistrationPrompt from '@components/RegistrationPrompt'
-import { ManagerRegisterState } from '@stores/managerRegisterInfoStore'
-import managerRegisterInfoStore from '@stores/managerRegisterInfoStore'
-import { ManagerPageContainer } from './ManagerPage.style'
+import ManagerCompletedCard from '@components/ManagerCompletedCard/ManagerCompletedCard'
+import MyPageCardAccount from '@components/MyPageCard/Account/MyPageCardAccount'
+import DiscountModal from '@components/Modal/DiscountModal'
+import HeaderTitle from '@components/HeaderTitle/HeaderTitle'
 import icon from '@assets/managerMypage/등록증 아이콘.svg'
 import menuIcon from '@assets/managerMypage/메뉴아이콘.svg'
-import useModalStore from '@stores/modalStore'
-import { useEffect, useState } from 'react'
-import DiscountModal from '@components/Modal/DiscountModal'
-import ManagerCompletedCard from '@components/ManagerCompletedCard/ManagerCompletedCard'
-import storeInfoStore, { StoreInfo } from '@stores/storeInfoStore'
-import discountEventStore from '@stores/discountEventStore'
-import { generateUniqueId } from '@utils/generateUniqueId'
-import { useNavigate } from 'react-router-dom'
-import HeaderTitle from '@components/HeaderTitle/HeaderTitle'
-import MyPageCardAccount from '@components/MyPageCard/Account/MyPageCardAccount'
-import { StyledCard } from '@components/MyPageCard/MyPageCard.style'
+import ArrowImg from '@assets/StudentPage/arrow.svg'
 import {
   ImgBtnContainer,
   Btn,
   StyledArrow,
 } from '@components/MyPageCard/MyPageCardTop/MyPageCardTop.style'
-import ArrowImg from '@assets/StudentPage/arrow.svg'
+import { StyledCard } from '@components/MyPageCard/MyPageCard.style'
+import { ManagerPageContainer } from './ManagerPage.style'
+import axios from 'axios'
+import managerRegisterInfoStore from '@stores/managerRegisterInfoStore'
 
 export default function ManagerPage() {
   const navigate = useNavigate()
-  const { isRegistered, setIsRegistered, setManagerRegistrationInfo } =
+  const { isRegistered, isStoreRegistered, ownerNickname, updateFromApi } =
     managerRegisterInfoStore()
-  const { isStoreRegistered, setStoreRegistered } = storeInfoStore()
-  const storeInfos = storeInfoStore((state) => state.storeInfos)
-  const discountEvents = discountEventStore.getState().discountEvents
-  const { openModal } = useModalStore()
-  const [businessData, setBusinessData] = useState<ManagerRegisterState | null>(
-    null,
-  )
 
-  useEffect(() => {
-    if (isRegistered) {
-      setBusinessData(managerRegisterInfoStore.getState())
-    } else {
-      setBusinessData(null)
+  const fetchOwnerData = async () => {
+    try {
+      const response = await axios.get(
+        `${import.meta.env.VITE_API_BASE_URL}/v1/users/owner/mypage`,
+        {
+          headers: {
+            Authorization: `Bearer ${import.meta.env.VITE_APP_API_TOKEN}`,
+          },
+        },
+      )
+
+      if (response.data.isSuccess) {
+        const { ownerId, ownerNickname, storeId, storeName } =
+          response.data.result
+
+        updateFromApi({
+          ownerId,
+          ownerNickname,
+          storeId,
+          storeName,
+        })
+      } else {
+        console.error(
+          'Failed to fetch owner mypage data:',
+          response.data.message,
+        )
+      }
+    } catch (error) {
+      console.error('사장님 마이페이지 오류', error)
     }
-  }, [isRegistered])
+  }
 
-  useEffect(() => {
-    console.log('Updated Store Infos:', storeInfos)
-  }, [storeInfos])
-
-  const handleManagerRegisterClick = (): void => {
-    setIsRegistered(true)
-    setManagerRegistrationInfo({
-      managerName: '고서현',
-      isRegistered: true,
-      registrationNumber: 12345678,
-      businessName: '예제 사업자명',
-      businessAddress: '예제 주소',
-      industry: '업태',
-      item: '종목',
-    })
+  const handleManagerRegisterClick = async () => {
+    await fetchOwnerData()
     navigate('/businessdocupload')
   }
 
-  const handleStoreRegisterClick = (): void => {
-    setStoreRegistered(true)
-    openModal()
+  const handleStoreRegisterClick = async () => {
+    await fetchOwnerData()
+    navigate('/firstregisterstoreinfo')
   }
+
+  useEffect(() => {
+    fetchOwnerData()
+  }, [])
+
+  const renderRegisteredContent = () => (
+    <>
+      <RegistrationPrompt
+        isRegistered={true}
+        businessData={[managerRegisterInfoStore.getState()]}
+        ownerNickname={ownerNickname}
+      />
+      <ImgBtnContainer $gap="12px">
+        <img src={menuIcon} alt="메뉴 아이콘" />
+        <Btn onClick={handleStoreRegisterClick} $padding="18px">
+          가게 등록하러 가기
+          <StyledArrow src={ArrowImg} />
+        </Btn>
+      </ImgBtnContainer>
+    </>
+  )
+
+  const renderUnregisteredContent = () => (
+    <>
+      <RegistrationPrompt
+        ownerNickname={ownerNickname}
+        isRegistered={false}
+        businessData={null}
+      />
+      <ImgBtnContainer $gap="18px">
+        <img src={icon} alt="등록증 아이콘" />
+        <Btn onClick={handleManagerRegisterClick} $padding="18px">
+          사업자 정보 등록하기
+          <StyledArrow src={ArrowImg} />
+        </Btn>
+      </ImgBtnContainer>
+    </>
+  )
+
   return (
     <ManagerPageContainer>
       <HeaderTitle title="마이페이지" $icon="notification" />
-
       {isStoreRegistered ? (
         <ManagerCompletedCard />
       ) : (
         <StyledCard $paddingtop="35px" $paddingbottom="26px">
-          <RegistrationPrompt
-            isRegistered={isRegistered}
-            businessData={businessData ? [businessData] : null}
-          />
-          {isRegistered && businessData ? (
-            <>
-              <ImgBtnContainer $gap="12px">
-                <img src={menuIcon} alt="메뉴 아이콘" />
-                <Btn onClick={handleStoreRegisterClick} $padding="18px">
-                  가게 등록하러 가기
-                  <StyledArrow src={ArrowImg} />
-                </Btn>
-              </ImgBtnContainer>
-            </>
-          ) : (
-            <>
-              <ImgBtnContainer $gap="18px">
-                <img src={icon} alt="등록증 아이콘" />
-                <Btn onClick={handleManagerRegisterClick} $padding="18px">
-                  사업자 정보 등록하기
-                  <StyledArrow src={ArrowImg} />
-                </Btn>
-              </ImgBtnContainer>
-            </>
-          )}
+          {isRegistered
+            ? renderRegisteredContent()
+            : renderUnregisteredContent()}
         </StyledCard>
       )}
       <MyPageCardAccount />
-      {isStoreRegistered ? <DiscountModal /> : null}
+      {isStoreRegistered && <DiscountModal />}
     </ManagerPageContainer>
   )
 }

--- a/src/pages/ManagerPage/ManagerPage.tsx
+++ b/src/pages/ManagerPage/ManagerPage.tsx
@@ -15,8 +15,8 @@ import {
 } from '@components/MyPageCard/MyPageCardTop/MyPageCardTop.style'
 import { StyledCard } from '@components/MyPageCard/MyPageCard.style'
 import { ManagerPageContainer } from './ManagerPage.style'
-import axios from 'axios'
 import managerRegisterInfoStore from '@stores/managerRegisterInfoStore'
+import { getOwnerMypage } from '@apis/getOwnerMypage'
 
 export default function ManagerPage() {
   const navigate = useNavigate()
@@ -25,18 +25,10 @@ export default function ManagerPage() {
 
   const fetchOwnerData = async () => {
     try {
-      const response = await axios.get(
-        `${import.meta.env.VITE_API_BASE_URL}/v1/users/owner/mypage`,
-        {
-          headers: {
-            Authorization: `Bearer ${import.meta.env.VITE_APP_API_TOKEN}`,
-          },
-        },
-      )
+      const response = await getOwnerMypage()
 
-      if (response.data.isSuccess) {
-        const { ownerId, ownerNickname, storeId, storeName } =
-          response.data.result
+      if (response.isSuccess) {
+        const { ownerId, ownerNickname, storeId, storeName } = response.result
 
         updateFromApi({
           ownerId,
@@ -45,10 +37,7 @@ export default function ManagerPage() {
           storeName,
         })
       } else {
-        console.error(
-          'Failed to fetch owner mypage data:',
-          response.data.message,
-        )
+        console.error('Failed to fetch owner mypage data:', response.message)
       }
     } catch (error) {
       console.error('사장님 마이페이지 오류', error)

--- a/src/pages/StoreInfoDeletePage/StoreInfoDeletePage.tsx
+++ b/src/pages/StoreInfoDeletePage/StoreInfoDeletePage.tsx
@@ -13,12 +13,14 @@ import storeInfoStore from '@stores/storeInfoStore'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import HeaderTitle from '@components/HeaderTitle/HeaderTitle'
+import managerRegisterInfoStore from '@stores/managerRegisterInfoStore'
 
 export default function StoreInfoDeletePage() {
   const navigate = useNavigate()
   const [isChecked, setIsChecked] = useState<boolean>(false)
   const storeInfos = storeInfoStore((state) => state.storeInfos)
   const removeStoreInfo = storeInfoStore((state) => state.removeStoreInfo)
+  const { ownerNickname } = managerRegisterInfoStore()
 
   // 현재 등록된 가게 정보가 없을 경우에 대한 처리
   const storeId = storeInfos.length > 0 ? storeInfos[0].id : null
@@ -56,8 +58,7 @@ export default function StoreInfoDeletePage() {
         onClick={() => navigate('/storeInfo-edit')}
       />
       <SubTitle>
-        {/* 고서현 사장님 부분은 로그인 정보 받아와서 이름으로 랜더링 해주기 */}
-        고서현 사장님! <br />
+        {ownerNickname} 사장님! <br />
         가게를 정말 삭제할까요?
       </SubTitle>
       <Content>

--- a/src/pages/StoreInfoEditPage/StoreInfoEditPage.tsx
+++ b/src/pages/StoreInfoEditPage/StoreInfoEditPage.tsx
@@ -9,9 +9,11 @@ import {
 import { Option } from 'src/types/ButtonOpionTypes'
 import { useNavigate } from 'react-router-dom'
 import HeaderTitle from '@components/HeaderTitle/HeaderTitle'
+import managerRegisterInfoStore from '@stores/managerRegisterInfoStore'
 
 export default function StoreInfoEditPage() {
   const navigate = useNavigate()
+  const { ownerNickname } = managerRegisterInfoStore()
 
   const [selectedOption, setSelectedOption] = useState<string | null>(null)
 
@@ -41,8 +43,7 @@ export default function StoreInfoEditPage() {
         onClick={() => navigate('/manager')}
       />
       <SubTitle>
-        {/* 고서현 사장님 부분은 로그인 정보 받아와서 이름으로 랜더링 해주기 */}
-        고서현 사장님! <br />
+        {ownerNickname} 사장님! <br />
         어떤 정보를 수정할까요?
       </SubTitle>
       <EditOptions>

--- a/src/pages/ThirdRegisterStoreInfo/ThirdRegisterStoreInfo.tsx
+++ b/src/pages/ThirdRegisterStoreInfo/ThirdRegisterStoreInfo.tsx
@@ -22,9 +22,11 @@ import { useState } from 'react'
 import { RegisterMenu } from '@components/RegisterMenu/RegisterMenu'
 import { Menu } from 'src/types/ThirdRegisterStoreInfoTypes'
 import HeaderTitle from '@components/HeaderTitle/HeaderTitle'
+import managerRegisterInfoStore from '@stores/managerRegisterInfoStore'
 
 export default function ThirdRegisterStoreInfo() {
   const [isError, setIsError] = useState<boolean>(false)
+  const { setIsStoreRegistered } = managerRegisterInfoStore()
 
   const navigate = useNavigate()
   const handleBack = () => {
@@ -57,6 +59,7 @@ export default function ThirdRegisterStoreInfo() {
     if (isFormValid) {
       setIsError(false)
       console.log('폼 유효함')
+      setIsStoreRegistered(true)
       navigate('/registerstoresuccess')
     } else {
       setIsError(true)

--- a/src/stores/managerRegisterInfoStore.ts
+++ b/src/stores/managerRegisterInfoStore.ts
@@ -2,33 +2,49 @@ import { create } from 'zustand'
 
 export interface ManagerRegisterState {
   managerName: string
-  isRegistered: boolean
+  isRegistered?: boolean
   registrationNumber: number
   businessName: string
   businessAddress: string
   industry: string
   item: string
+  isStoreRegistered?: boolean
+  ownerId: number
+  ownerNickname: string
+  storeId: number
+  storeName: string
   setIsRegistered: (isRegistered: boolean) => void
+  setIsStoreRegistered: (isStoreRegistered: boolean) => void
   setManagerRegistrationInfo: (
     info: Partial<
       Omit<
         ManagerRegisterState,
-        'setIsRegistered' | 'setManagerRegistrationInfo'
+        | 'setIsRegistered'
+        | 'setIsStoreRegistered'
+        | 'setManagerRegistrationInfo'
       >
     >,
   ) => void
+  updateFromApi: (data: Partial<ManagerRegisterState>) => void
 }
 
 const managerRegisterInfoStore = create<ManagerRegisterState>((set) => ({
-  managerName: '고서현',
+  managerName: '',
   isRegistered: false,
   registrationNumber: 1111,
   businessName: '',
   businessAddress: '',
   industry: '',
   item: '',
+  isStoreRegistered: false,
+  ownerId: 0,
+  ownerNickname: '',
+  storeId: 0,
+  storeName: '',
   setIsRegistered: (isRegistered) => set({ isRegistered }),
+  setIsStoreRegistered: (isStoreRegistered) => set({ isStoreRegistered }),
   setManagerRegistrationInfo: (info) => set((state) => ({ ...state, ...info })),
+  updateFromApi: (data) => set((state) => ({ ...state, ...data })),
 }))
 
 export default managerRegisterInfoStore


### PR DESCRIPTION
## 📢 기능 설명

- 사장님 마이페이지 api를 연결했습니다.
- 기존 코드에서 필요없는 부분, 임시로 정해둔 부분 전부 제거 후 코드 작성했습니다!
- 크게 중요한 건 사업자 등록증 여부를 판단하는 `isRegistered`와 가게 등록 여부를 판단하는 `isStoreRegistered`가 있습니다.
  - `managerRegisterInfoStore.ts` 타입에 등록 여부 / 여부 판단 함수 + api 결과값을 저장할 변수들을 추가했습니다.
  - 플로우를 설명하자면 
  1. `첫 번째 manager` - isRegistered와 isStoreRegistered 둘 다 false 
  2. 사업자 등록증 페이지에서 성공하면 isRegistered을 true로 변경하여 store에 있는 값 업데이트 
  3. `두 번째 manager`- isRegistered는 true, isStoreRegistered는 false 
  4. 가게 등록 페이지에서 성공하면 isStoreRegistered을 true로 변경하여 store에 있는 값 업데이트 
  5. `세 번째 manager` - isRegistered와 isStoreRegistered 둘 다 true 
  - 이런 흐름입니다!
- 사장님 이름(아이디)은 `const { ownerNickname } = managerRegisterInfoStore()` 이렇게 받아올 수 있습니다.
- 아이디와 이름 두 개가 있어야 하는데 현재 하나만 존재해서 아이디는 그냥 mock입니다 지금! 추후 백엔드에게 응답 수정 요청 후 수정하겠습니다.

https://github.com/user-attachments/assets/1523942a-5a91-48a4-a75b-972750b5a6e7

1. `첫 번째 manager` - isRegistered와 isStoreRegistered 둘 다 false 
2. 사업자 등록증 페이지에서 성공하면 isRegistered을 true로 변경하여 store에 있는 값 업데이트 

https://github.com/user-attachments/assets/1f49741d-4e60-4ae4-8f3a-bac763f1513c

3. `두 번째 manager`- isRegistered는 true, isStoreRegistered는 false 
  4. 가게 등록 페이지에서 성공하면 isStoreRegistered을 true로 변경하여 store에 있는 값 업데이트 

https://github.com/user-attachments/assets/2c9e3738-340e-48b9-b196-78974ac41963

  5. `세 번째 manager` - isRegistered와 isStoreRegistered 둘 다 true 

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #49 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!
- [] 질문인데요, 페이지 내 이동은 값이 바뀔 일이 없는데 새로고침은 값이 초기화 되는게 맞는 거죠? 스토리지도 아니고 store니까...?

<br>

## ✅ 체크리스트

- [X] PR 제목 규칙 잘 지켰는가?
- [X] 추가/수정사항을 설명하였는가?
- [X] 이슈넘버를 적었는가?
- [X] Approve 하기 전 확인 사항 체크했는가?
