### PR TITLE
(#104)fix/shop detail

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc -b && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --host",
+    "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",

--- a/src/components/ShopMenu/ShopMenu.style.ts
+++ b/src/components/ShopMenu/ShopMenu.style.ts
@@ -38,8 +38,8 @@ export const InfoContainer = styled.div`
   justify-content: center;
   gap: 3px;
 `
-export const DiscountContainer = styled.div<{ onsale: boolean }>`
+export const DiscountContainer = styled.div<{ $issale: boolean }>`
   display: flex;
   flex-direction: row;
-  gap: ${(props) => (props.onsale ? '8px' : '0px')};
+  gap: ${(props) => (props.$issale ? '8px' : '0px')};
 `

--- a/src/components/ShopMenu/ShopMenu.tsx
+++ b/src/components/ShopMenu/ShopMenu.tsx
@@ -16,7 +16,7 @@ interface ShopMenuProps {
   fixprice: number // 정가 타입
   discountrate: string // 할인율 타입
   saleprice: number // 판매가 타입
-  onsale: boolean
+  issale: boolean
 }
 
 export default function ShopMenu({
@@ -25,17 +25,17 @@ export default function ShopMenu({
   fixprice,
   discountrate,
   saleprice,
-  onsale,
+  issale,
 }: ShopMenuProps) {
   return (
     <MenuContainer>
       <MenuImg src={img} />
       <InfoContainer>
         <MenuTitle>{title}</MenuTitle>
-        <MenuFixPrice>{onsale ? fixprice : null}</MenuFixPrice>
-        <DiscountContainer onsale={onsale}>
-          <MenuDiscountRate>{onsale ? discountrate : null}</MenuDiscountRate>
-          <MenuSalePrice>{onsale ? saleprice : fixprice}</MenuSalePrice>
+        <MenuFixPrice>{issale ? fixprice : null}</MenuFixPrice>
+        <DiscountContainer $issale={issale}>
+          <MenuDiscountRate>{issale ? discountrate : null}</MenuDiscountRate>
+          <MenuSalePrice>{issale ? saleprice : fixprice}</MenuSalePrice>
         </DiscountContainer>
       </InfoContainer>
     </MenuContainer>

--- a/src/pages/MemberType/MemberType.style.ts
+++ b/src/pages/MemberType/MemberType.style.ts
@@ -26,6 +26,7 @@ export const MemberButton = styled.button`
   border-style: solid;
   border-radius: 20px;
   border-color: #d7d7d7;
+  color: #000000;
   width: 342px;
   height: 53px;
   padding: 12px;

--- a/src/pages/ShopDetail/ShopDetail.style.ts
+++ b/src/pages/ShopDetail/ShopDetail.style.ts
@@ -37,12 +37,12 @@ export const ShopTitle = styled.div`
   margin-bottom: 4px;
 `
 
-export const ShopInfoContainer = styled.div<{ onSale: boolean }>`
+export const ShopInfoContainer = styled.div<{ $issale: boolean }>`
   display: flex;
   flex-direction: column;
   padding: 0px 23px;
   position: relative;
-  top: ${(props) => (props.onSale ? '157px' : '177px')};
+  top: ${(props) => (props.$issale ? '157px' : '177px')};
 `
 
 export const EventContainer = styled.div`

--- a/src/pages/ShopDetail/ShopDetail.tsx
+++ b/src/pages/ShopDetail/ShopDetail.tsx
@@ -105,7 +105,7 @@ export default function ShopDetail() {
       <BackBar storeCategory={handleBackBar()} />
       <MenuHeader>
         <BkImg $imgsrc={storeInfo.bannerUrl}>
-          <ShopInfoContainer onSale={storeInfo.onSale}>
+          <ShopInfoContainer $issale={storeInfo.onSale}>
             <ShopTitle>{storeInfo.storeName}</ShopTitle>
             {storeInfo.onSale ? <Event> 가게 특별 할인</Event> : null}
           </ShopInfoContainer>
@@ -145,7 +145,7 @@ export default function ShopDetail() {
                 fixprice={menu.menuPrice}
                 discountrate={menu.discountRate + '%'}
                 saleprice={menu.menuPrice - menu.discountPrice}
-                onsale={storeInfo.onSale}
+                issale={storeInfo.onSale}
               />
             ))}
         </MenuContainer>


### PR DESCRIPTION
## 📢 기능 설명

가게 상세에서  onSale props가 이벤트 핸들러로 인식되는 오류 해결했습니다
on을 붙이면 이벤트 핸들러로 인식해버린다는군요...ㅠ

모바일에서 버튼 파란색으로 보이는 문제도 수정했습니다
membertype 버튼만 수정하긴 했는데 다른 color를 따로 지정하지 않은 버튼들이 더 있을까요?
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #104 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?
